### PR TITLE
Fix ads between posts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,11 @@
             "name": "Daniël Klabbers",
             "email": "daniel+flarum@klabbers.email",
             "homepage": "http://hyn.me"
+        },
+        {
+            "name": "Clark Winkelmann",
+            "email": "clark.winkelmann@gmail.com",
+            "homepage": "https://clarkwinkelmann.com"
         }
     ],
     "support": {

--- a/js/forum/src/addAdBetweenPosts.js
+++ b/js/forum/src/addAdBetweenPosts.js
@@ -3,93 +3,26 @@ import app from 'flarum/app';
 import PostStream from 'flarum/components/PostStream';
 
 export default function() {
-    extend(PostStream.prototype, 'posts', function(posts) {
+    extend(PostStream.prototype, 'view', function(component) {
         const advertisement = app.forum.attribute('flagrow.ads.between-posts');
 
-        if (posts.length && advertisement) {
+        if (advertisement && component.children.length) {
             const between = parseInt(app.forum.attribute('flagrow.ads.between-n-posts') || 5);
+            // We need to copy all comments first, otherwise there is no way to detect and jump the last comment
+            const commentPosts = component.children.filter(post => post.attrs['data-type'] == 'comment');
 
-            var pointers = [],
-                internal = 0;
-
-            posts.forEach((post, i) => {
-                if (i > 0 && i < posts.length && post && post.number() && post.contentType() == 'comment') {
-                    internal++;
-
-                    if (internal === between) {
-                        pointers.push(i);
-                        internal = 0;
-                    }
+            // Insert an inside every n comment
+            commentPosts.forEach((post, i) => {
+                if (i > 0 && (i + 1) % between === 0 && i < commentPosts.length - 1) {
+                    post.children.push(
+                        m('div.Flagrow-Ads-fake-poststream-item',
+                            m('article.Post.EventPost',
+                                m('div.Flagrow-Ads-between-posts.EventPost-info', m.trust(advertisement))
+                            )
+                        )
+                    );
                 }
-            });
-
-
-            var offset = 0;
-            pointers.forEach(number => {
-
-                var index = number + offset;
-
-                posts.splice(index, 0, app.store.createRecord('posts', {attributes: {
-                    contentHtml: advertisement,
-                    time: new Date(),
-                    contentType: 'ad',
-                    canReply: false,
-                    canFlag: false,
-                    canLike: false,
-                    canDelete: false,
-                    canApprove: false,
-                    canEdit: false,
-                    isApproved: true,
-                    number: index
-                }}));
-
-                offset++;
             });
         }
     });
-    //
-    // extend(PostStream.prototype, 'view', function(component) {
-    //     const advertisement = app.forum.attribute('flagrow.ads.between-posts');
-    //     const between = parseInt(app.forum.attribute('flagrow.ads.between-n-posts') || 5);
-    //
-    //     if (advertisement && component.children.length) {
-    //         var pointers = [],
-    //             internal = 0;
-    //
-    //         component.children.forEach((post, i) => {
-    //             if (i > 0 && post.attrs['data-type'] == 'comment' && i != component.children.length) {
-    //                 internal++;
-    //
-    //                 if (internal >= between) {
-    //                     pointers.push(i);
-    //                     internal = 0;
-    //                 }
-    //             }
-    //         });
-    //
-    //         if (pointers.length) {
-    //             // FiPo is the First Post.
-    //             var FiPo = component.children[0];
-    //             FiPo.children = [m('article', {className: 'Post EventPost AdPost'}, [
-    //                 m('div', {className: 'Flagrow-Ads-between-posts EventPost-info'}, [
-    //                     m.trust(advertisement)
-    //                 ])
-    //             ])];
-    //             FiPo.attrs['data-type'] = 'ad';
-    //             FiPo.attrs['data-id'] = null;
-    //
-    //             internal = 0;
-    //
-    //             pointers.forEach(index => {
-    //                 // Increment the index to offset for already added ads.
-    //                 var index = index + internal;
-    //                 FiPo.attrs['data-index'] = index;
-    //                 FiPo.attrs['data-number'] = index;
-    //                 console.log(index, internal, FiPo.attrs);
-    //                 component.children.splice(index, 0, FiPo);
-    //                 internal++;
-    //             });
-    //         }
-    //     }
-    // });
 }

--- a/less/forum/adsBetweenPosts.less
+++ b/less/forum/adsBetweenPosts.less
@@ -1,0 +1,4 @@
+.Flagrow-Ads-fake-poststream-item {
+    // Mimic `.PostStream-item` borders even if we are in fact inside one
+    border-top: 1px solid #e8ecf3;
+}

--- a/src/Listeners/AddClientAssets.php
+++ b/src/Listeners/AddClientAssets.php
@@ -23,6 +23,7 @@ class AddClientAssets
         if ($app->isForum()) {
             $app->addAssets([
                 __DIR__.'/../../js/forum/dist/extension.js',
+                __DIR__.'/../../less/forum/adsBetweenPosts.less'
             ]);
             $app->addBootstrapper('flagrow/ads/main');
         }


### PR DESCRIPTION
After many trials and errors on the trail of @Luceos, I managed to find a solution that satisfies most (all ?) of the problems we had:

- Posts order is maintained when posting/editing
- The scrubber is happy and reflects current post
- The url reflects the current post id (not something from the ad at the top of the screen)

The following solutions were tested without success:

- override `PostStream.posts()`
- override `Discussion.postIds()`

It looks like something is reordering the posts **after** the Mithril object is returned from `PostStream.views()`, probably based on the content of `data-index`, `data-number` or `data-id`. Given the way `PostStream` gives these numbers out there is no way to push an item with a valid, yet non-duplicated value of index/number/id without forcing to change all the numbers from all posts until the end of the discussion.

The current solution also works if we push ads items directly in the stream (they don't get reordered randomly). However, this breaks the `PostStreamScrubber`.