### PR TITLE
Allow extension to be used on dev-master Flarum/core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "source": "https://github.com/flagrow/ads"
     },
     "require": {
-        "flarum/core": "0.1.0-beta.6"
+        "flarum/core": "^0.1.0-beta.6"
     },
     "extra": {
         "flarum-extension": {


### PR DESCRIPTION
Small error I noticed while trying to update my core to dev-master.